### PR TITLE
fix phantasm verification

### DIFF
--- a/cmd/dxworker/main.go
+++ b/cmd/dxworker/main.go
@@ -211,7 +211,7 @@ func (app *application) run() error {
 	}()
 
 	// delay worker start to give leeway on phantasm webhook to be online
-	time.Sleep(10 * time.Second)
+	time.Sleep(5 * time.Second)
 	go app.worker.Start()
 
 	<-quit

--- a/cmd/dxworker/main.go
+++ b/cmd/dxworker/main.go
@@ -1,12 +1,17 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"log/slog"
+	nethttp "net/http"
 	"os"
 	"os/signal"
 	"time"
 
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
 	"github.com/kudarap/dotagiftx"
 	"github.com/kudarap/dotagiftx/config"
 	"github.com/kudarap/dotagiftx/logging"
@@ -52,6 +57,7 @@ func main() {
 
 type application struct {
 	config config.Config
+	server *nethttp.Server
 	worker *worker.Worker
 	logger *logrus.Logger
 
@@ -161,8 +167,18 @@ func (app *application) setup() error {
 	app.worker.AddJob(jobs.NewSweepMarket(marketStg, logging.WithPrefix(logger, "job_sweep_market")))
 	app.worker.AddJob(jobs.NewSweepPhantasmCache(phantasmSvc, logging.WithPrefix(logger, "job_sweep_phantasm")))
 
+	// Server setup.
+	logSvc.Println("setting up http server...")
+	app.server = setupServer(app.config.Addr, phantasmSvc)
+
 	app.closerFn = func() {
 		logSvc.Println("closing and stopping app...")
+		// Force server shutdown after shutdownTimeout and this was added because of SSE's opened connection.
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+		defer cancel()
+		if err = app.server.Shutdown(ctx); err != nil {
+			logSvc.Println("could not shutdown http server", err)
+		}
 		if err = app.worker.Stop(); err != nil {
 			logSvc.Fatal("could not stop worker", err)
 		}
@@ -183,6 +199,15 @@ func (app *application) run() error {
 	// Handle quit on SIGINT (CTRL-C).
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, os.Interrupt)
+
+	// Handle error on server start.
+	svlog := app.contextLog("server")
+	go func() {
+		svlog.Infoln("starting server on", app.config.Addr)
+		if err := app.server.ListenAndServe(); err != nil && !errors.Is(err, nethttp.ErrServerClosed) {
+			svlog.Fatalf("could not listen and serve on %s: %v\n", app.config.Addr, err)
+		}
+	}()
 
 	go app.worker.Start()
 
@@ -228,6 +253,31 @@ func setupRedis(cfg redis.Config) (c *redis.Client, err error) {
 
 	err = connRetry("redis", fn)
 	return
+}
+
+func setupServer(addr string, svc *phantasm.Service) *nethttp.Server {
+	r := chi.NewRouter()
+	r.Use(middleware.Recoverer)
+	r.Post("/webhook/phantasm/{steam_id}", func(w nethttp.ResponseWriter, r *nethttp.Request) {
+		id := chi.URLParam(r, "steam_id")
+		secret := r.Header.Get(phantasm.WebhookAuthHeader)
+		if err := svc.SaveInventory(r.Context(), id, secret, r.Body); err != nil {
+			w.WriteHeader(nethttp.StatusOK)
+			_, _ = fmt.Fprintf(w, "error: %s", err)
+			return
+		}
+
+		w.WriteHeader(nethttp.StatusOK)
+		_, _ = fmt.Fprintf(w, "ok")
+	})
+
+	const readWriteTimeout = time.Second * 15
+	return &nethttp.Server{
+		Addr:         addr,
+		Handler:      r,
+		WriteTimeout: readWriteTimeout,
+		ReadTimeout:  readWriteTimeout,
+	}
 }
 
 func connRetry(name string, fn func() error) error {

--- a/cmd/dxworker/main.go
+++ b/cmd/dxworker/main.go
@@ -120,7 +120,7 @@ func (app *application) setup() error {
 	)
 
 	// Setup application worker
-	tp := worker.NewTaskProcessor(time.Second, queue, inventorySvc, deliverySvc, assetSource, phantasmSvc)
+	tp := worker.NewTaskProcessor(time.Second, queue, inventorySvc, deliverySvc, assetSource, phantasmSvc, slogger)
 	app.worker = worker.New(tp)
 	app.worker.SetLogger(app.contextLog("worker"))
 	app.worker.AddJob(jobs.NewRecheckInventory(

--- a/cmd/dxworker/main.go
+++ b/cmd/dxworker/main.go
@@ -108,7 +108,8 @@ func (app *application) setup() error {
 	queue := rethink.NewQueue(rethinkClient)
 
 	// Service inits.
-	slogger := slog.Default()
+	th := slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug})
+	slogger := slog.New(th)
 	logSvc.Println("setting up services...")
 	inventorySvc := dotagiftx.NewInventoryService(inventoryStg, marketStg, catalogStg)
 	deliverySvc := dotagiftx.NewDeliveryService(deliveryStg, marketStg)
@@ -209,6 +210,8 @@ func (app *application) run() error {
 		}
 	}()
 
+	// delay worker start to give leeway on phantasm webhook to be online
+	time.Sleep(10 * time.Second)
 	go app.worker.Start()
 
 	<-quit

--- a/dota2/heroes.go
+++ b/dota2/heroes.go
@@ -117,7 +117,7 @@ var AllHeroes = []Hero{
 		"agility",
 	},
 	{
-		"rattletrap",
+		"clockwerk",
 		"Clockwerk",
 		"rattletrap.png",
 		"strength",
@@ -345,7 +345,7 @@ var AllHeroes = []Hero{
 		"strength",
 	},
 	{
-		"magnataur",
+		"magnus",
 		"Magnus",
 		"magnataur.png",
 		"universal",
@@ -405,13 +405,13 @@ var AllHeroes = []Hero{
 		"agility",
 	},
 	{
-		"furion",
+		"naturesprophet",
 		"Nature's Prophet",
 		"furion.png",
 		"universal",
 	},
 	{
-		"necrolyte",
+		"necrophos",
 		"Necrophos",
 		"necrolyte.png",
 		"intelligence",
@@ -447,7 +447,7 @@ var AllHeroes = []Hero{
 		"intelligence",
 	},
 	{
-		"obsidiandestroyer",
+		"outworldndestroyer",
 		"Outworld Destroyer",
 		"obsidian_destroyer.png",
 		"intelligence",
@@ -543,7 +543,7 @@ var AllHeroes = []Hero{
 		"intelligence",
 	},
 	{
-		"nevermore",
+		"shadowfiend",
 		"Shadow Fiend",
 		"nevermore.png",
 		"agility",
@@ -753,13 +753,13 @@ var AllHeroes = []Hero{
 		"intelligence",
 	},
 	{
-		"skeletonking",
+		"wraithking",
 		"Wraith King",
 		"skeleton_king.png",
 		"strength",
 	},
 	{
-		"zuus",
+		"zeus",
 		"Zeus",
 		"zuus.png",
 		"intelligence",

--- a/dota2/heroes.go
+++ b/dota2/heroes.go
@@ -255,7 +255,7 @@ var AllHeroes = []Hero{
 		"intelligence",
 	},
 	{
-		"wisp",
+		"io",
 		"Io",
 		"wisp.png",
 		"universal",
@@ -447,7 +447,7 @@ var AllHeroes = []Hero{
 		"intelligence",
 	},
 	{
-		"outworldndestroyer",
+		"outworlddestroyer",
 		"Outworld Destroyer",
 		"obsidian_destroyer.png",
 		"intelligence",
@@ -639,7 +639,7 @@ var AllHeroes = []Hero{
 		"strength",
 	},
 	{
-		"shredder",
+		"timbersaw",
 		"Timbersaw",
 		"shredder.png",
 		"strength",
@@ -675,7 +675,7 @@ var AllHeroes = []Hero{
 		"strength",
 	},
 	{
-		"abyssalunderlord",
+		"underlord",
 		"Underlord",
 		"abyssal_underlord.png",
 		"strength",

--- a/phantasm/crawler.go
+++ b/phantasm/crawler.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"math/rand/v2"
 	"net/http"
 	"os"
 	"reflect"
@@ -65,6 +66,7 @@ func Main(args map[string]interface{}) map[string]interface{} {
 	var lastAssetID string
 	var invent *inventory
 	for {
+		time.Sleep(time.Duration(100+rand.IntN(900)) * time.Millisecond)
 		parts++
 		log.Println("requesting part...", parts)
 		next, status, err := get(ctx, steamID, limit, lastAssetID)

--- a/phantasm/crawler.go
+++ b/phantasm/crawler.go
@@ -298,7 +298,7 @@ func structToMap(data interface{}) map[string]interface{} {
 	reflectValue := reflect.ValueOf(data)
 	reflectValue = reflect.Indirect(reflectValue)
 
-	if v.Kind() == reflect.Ptr {
+	if v.Kind() == reflect.Pointer {
 		v = v.Elem()
 	}
 	for i := 0; i < v.NumField(); i++ {

--- a/phantasm/phantasm.go
+++ b/phantasm/phantasm.go
@@ -369,6 +369,7 @@ func (s *Service) sendCrawlRequest(
 			s.logger.InfoContext(ctx, "current crawler unavailable, new crawler elected",
 				"old", extractCrawlerID(crawlerURL),
 				"new", elected,
+				"err", err,
 			)
 		}
 		return nil, err

--- a/phantasm/phantasm.go
+++ b/phantasm/phantasm.go
@@ -168,7 +168,7 @@ func (s *Service) crawlWait(ctx context.Context, steamID string) (*inventory, er
 	if localFile != nil {
 		logger.DebugContext(ctx, "local inventory ready")
 
-		// when the hash still exists, the validity file age is still valid by inventoryHashExpr.
+		// when the hash still exists, the validity file age is still valid by inventory hash.
 		hash, err := s.cooldown.InventoryHash(ctx, steamID)
 		if err != nil {
 			return nil, err

--- a/phantasm/phantasm.go
+++ b/phantasm/phantasm.go
@@ -422,7 +422,7 @@ func (s *Service) sendCrawlRequest(
 		}
 
 		if shouldRetry {
-			err = retryRequest(func() error {
+			err = retryRequest(func(attempt int) error {
 				current := s.currentCrawlerID()
 				next := s.electNewCrawler(ctx)
 				s.logger.InfoContext(ctx,
@@ -430,6 +430,7 @@ func (s *Service) sendCrawlRequest(
 					"current", current,
 					"next", next,
 					"err", err,
+					"attempt", attempt,
 				)
 
 				req.URL.Path = strings.ReplaceAll(req.URL.Path, current, next)
@@ -522,14 +523,14 @@ func extractCrawlerID(addr string) string {
 	return ss[len(ss)-1]
 }
 
-func retryRequest(fn func() error, maxAttempt int) error {
+func retryRequest(fn func(attempt int) error, maxAttempt int) error {
 	var err error
 	for i := 0; i < maxAttempt; i++ {
+		time.Sleep((time.Second * 2) * time.Duration(i+1))
 		// return immediately on success with nil error
-		if err = fn(); err == nil {
+		if err = fn(i + 1); err == nil {
 			return nil
 		}
 	}
-
 	return err
 }

--- a/phantasm/phantasm.go
+++ b/phantasm/phantasm.go
@@ -40,8 +40,8 @@ const (
 )
 
 var (
-	errFileNotFound = fmt.Errorf("raw file not found")
-	errFileWaiting  = fmt.Errorf("waiting for file")
+	errFileNotFound = errors.New("raw file not found")
+	errFileWaiting  = errors.New("waiting for file")
 )
 
 type Service struct {
@@ -55,7 +55,8 @@ type Service struct {
 	crawlerCooldown  time.Duration
 	inventoryHashTTL time.Duration
 
-	electedCrawlerID int
+	electedCrawlerID  int
+	autoRotateCrawler bool
 }
 
 func NewService(config Config, cd cooldown, logger *slog.Logger) *Service {
@@ -72,6 +73,8 @@ func NewService(config Config, cd cooldown, logger *slog.Logger) *Service {
 		crawlerCooldown:  defaultCrawlerCD,
 		inventoryHashTTL: defaultInventoryHashTTL,
 		logger:           logger.With("module", "phantasm"),
+
+		autoRotateCrawler: true,
 	}
 }
 
@@ -157,7 +160,6 @@ func (s *Service) crawlWait(ctx context.Context, steamID string) (*inventory, er
 	crawlerID := extractCrawlerID(crawlerURL)
 	logger := s.logger.With("steam_id", steamID, "crawler_id", crawlerID)
 
-	logger.DebugContext(ctx, "fetch inventory and wait")
 	localFile, err := s.localInventoryFile(ctx, steamID)
 	if err != nil && !errors.Is(err, errFileNotFound) {
 		return nil, err
@@ -242,6 +244,7 @@ func (s *Service) crawlRemoteInventory(ctx context.Context, steamID string) erro
 	crawlerURL := s.config.Addrs[s.electedCrawlerID]
 	crawlerID := extractCrawlerID(crawlerURL)
 	logger := s.logger.With("steam_id", steamID, "crawler_id", crawlerID)
+	logger.InfoContext(ctx, "crawling remote inventory")
 
 	// check if crawler is ready
 	cd, err := s.cooldown.CrawlerCooldown(ctx, crawlerID)
@@ -277,6 +280,12 @@ func (s *Service) crawlRemoteInventory(ctx context.Context, steamID string) erro
 		"request_delay_ms", summary.RequestDelayMs,
 		"webhook_url", summary.WebhookURL,
 	)
+
+	// rotate crawler on success when auto rotate is enabled
+	if s.autoRotateCrawler {
+		cid := s.electNewCrawler(ctx)
+		s.logger.DebugContext(ctx, "rotating crawler", "id", cid)
+	}
 	return nil
 }
 
@@ -319,7 +328,7 @@ func (s *Service) localInventoryFile(ctx context.Context, steamID string) (*inve
 	return &inv, nil
 }
 
-func (s *Service) electNewCrawler(ctx context.Context) string {
+func (s *Service) electNewCrawler(ctx context.Context) (crawlerID string) {
 	crawler := extractCrawlerID(s.config.Addrs[s.electedCrawlerID])
 	cd, err := s.cooldown.CrawlerCooldown(ctx, crawler)
 	if err != nil {
@@ -343,7 +352,9 @@ func (s *Service) sendCrawlRequest(
 	crawlerURL string,
 	steamID string,
 	precheck bool,
-) (*CrawlSummary, error,
+) (
+	*CrawlSummary,
+	error,
 ) {
 	url := fmt.Sprintf("%s?steam_id=%s", crawlerURL, steamID)
 	if precheck {

--- a/phantasm/phantasm.go
+++ b/phantasm/phantasm.go
@@ -375,14 +375,32 @@ func (s *Service) sendCrawlRequest(
 		}
 
 		// only elect new crawler when not found and too much request
+		var shouldRetry bool
 		if statusCode == http.StatusNotFound || statusCode == http.StatusTooManyRequests {
-			elected := s.electNewCrawler(ctx)
-			s.logger.InfoContext(ctx, "current crawler unavailable, new crawler elected",
-				"old", extractCrawlerID(crawlerURL),
-				"new", elected,
-				"err", err,
-			)
+			shouldRetry = true
 		}
+
+		if shouldRetry {
+			err = retryRequest(func() error {
+				current := s.currentCrawlerID()
+				next := s.electNewCrawler(ctx)
+				s.logger.InfoContext(ctx,
+					"current crawler unavailable, new crawler elected and retying",
+					"current", current,
+					"next", next,
+					"err", err,
+				)
+
+				req.URL.Path = strings.ReplaceAll(req.URL.Path, current, next)
+				_, err1 := sendRequest(req, &summary)
+				return err1
+			}, 3)
+			// check success
+			if err == nil {
+				return &summary, nil
+			}
+		}
+
 		return nil, err
 	}
 	return &summary, nil
@@ -397,6 +415,11 @@ func (s *Service) setRequestHeaders() http.Header {
 
 func (s *Service) filePath(steamID string) string {
 	return filepath.Join(s.config.Path, fmt.Sprintf("%s.json", steamID))
+}
+
+func (s *Service) currentCrawlerID() string {
+	v := s.config.Addrs[s.electedCrawlerID]
+	return extractCrawlerID(v)
 }
 
 func (i *inventory) compat() steam.AllInventory {
@@ -452,4 +475,16 @@ type cooldown interface {
 func extractCrawlerID(addr string) string {
 	ss := strings.Split(addr, "/")
 	return ss[len(ss)-1]
+}
+
+func retryRequest(fn func() error, maxAttempt int) error {
+	var err error
+	for i := 0; i < maxAttempt; i++ {
+		// return immediately on success with nil error
+		if err = fn(); err == nil {
+			return nil
+		}
+	}
+
+	return err
 }

--- a/phantasm/phantasm.go
+++ b/phantasm/phantasm.go
@@ -209,7 +209,12 @@ func (s *Service) crawlWait(ctx context.Context, steamID string) (*inventory, er
 	}
 
 	// precheck to filter out private or failing remote inventory.
-	if _, err = s.sendCrawlRequest(ctx, crawlerURL, steamID, true); err != nil {
+	logger.DebugContext(ctx, "pre-check for private or failing remote inventory")
+	precheckSummary, err := s.sendCrawlRequest(ctx, crawlerURL, steamID, true)
+	if err != nil {
+		return nil, err
+	}
+	if err = s.setLocalInventoryPreHash(ctx, steamID, precheckSummary.PrecheckHash); err != nil {
 		return nil, err
 	}
 
@@ -284,10 +289,6 @@ func (s *Service) crawlRemoteInventory(ctx context.Context, steamID string) erro
 		"request_delay_ms", summary.RequestDelayMs,
 		"webhook_url", summary.WebhookURL,
 	)
-
-	if err = s.setLocalInventoryPreHash(ctx, steamID, summary.PrecheckHash); err != nil {
-		return err
-	}
 
 	// rotate crawler on success when auto rotate is enabled
 	if s.autoRotateCrawler {

--- a/phantasm/phantasm.go
+++ b/phantasm/phantasm.go
@@ -168,7 +168,7 @@ func (s *Service) crawlWait(ctx context.Context, steamID string) (*inventory, er
 	if localFile != nil {
 		logger.DebugContext(ctx, "local inventory ready")
 
-		// when the hash still exists, the validity file age is still valid by inventory hash.
+		// use local file when inventory hash still valid and refresh expiration.
 		hash, err := s.cooldown.InventoryHash(ctx, steamID)
 		if err != nil {
 			return nil, err
@@ -185,7 +185,7 @@ func (s *Service) crawlWait(ctx context.Context, steamID string) (*inventory, er
 			return localFile, nil
 		}
 
-		// pre-check before fetching
+		// pre-check remote inventory for changes before fetching
 		logger.DebugContext(ctx, "check remote inventory changes", "hash", hash)
 		changed, err := s.remoteInventoryChanged(ctx, steamID)
 		if err != nil {
@@ -194,9 +194,12 @@ func (s *Service) crawlWait(ctx context.Context, steamID string) (*inventory, er
 		}
 		if !changed {
 			logger.DebugContext(ctx, "remote inventory did not changed, falling back to local")
-			// refresh inventory file age
+			// refresh inventory file age and hash
 			n := time.Now()
 			if err = os.Chtimes(s.filePath(steamID), n, n); err != nil {
+				return nil, err
+			}
+			if err = s.cooldown.SetInventoryHash(ctx, steamID, hash, s.inventoryHashTTL); err != nil {
 				return nil, err
 			}
 			return localFile, nil
@@ -282,6 +285,10 @@ func (s *Service) crawlRemoteInventory(ctx context.Context, steamID string) erro
 		"webhook_url", summary.WebhookURL,
 	)
 
+	if err = s.setLocalInventoryPreHash(ctx, steamID, summary.PrecheckHash); err != nil {
+		return err
+	}
+
 	// rotate crawler on success when auto rotate is enabled
 	if s.autoRotateCrawler {
 		cid := s.electNewCrawler(ctx)
@@ -305,6 +312,13 @@ func (s *Service) remoteInventoryChanged(ctx context.Context, steamID string) (b
 	if err != nil {
 		return false, err
 	}
+	if currentHash == "" {
+		logger.DebugContext(ctx, "no inventory hash found, falling back to local pre-hash")
+		currentHash, err = s.localInventoryPreHash(ctx, steamID)
+		if err != nil {
+			logger.Error("local pre-hash error", "err", err)
+		}
+	}
 
 	logger.DebugContext(ctx, "comparing hashes", "current", currentHash, "new", result.PrecheckHash)
 	if err = s.cooldown.SetInventoryHash(ctx, steamID, result.PrecheckHash, s.inventoryHashTTL); err != nil {
@@ -327,6 +341,34 @@ func (s *Service) localInventoryFile(ctx context.Context, steamID string) (*inve
 		return nil, fmt.Errorf("unmarshal: %s", err)
 	}
 	return &inv, nil
+}
+
+func (s *Service) localInventoryPreHash(ctx context.Context, steamID string) (string, error) {
+	hash, err := os.ReadFile(s.filePathPreHash(steamID))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("open file: %s", err)
+	}
+
+	return string(hash), nil
+}
+
+func (s *Service) setLocalInventoryPreHash(ctx context.Context, steamID, hash string) error {
+	file, err := os.Create(s.filePathPreHash(steamID))
+	if err != nil {
+		return fmt.Errorf("pre-hash open file: %s", err)
+	}
+	defer func() {
+		if err = file.Close(); err != nil {
+			s.logger.Error("pre-hash close file", "error", err.Error())
+		}
+	}()
+	if _, err = file.WriteString(hash); err != nil {
+		return fmt.Errorf("pre-hash copy: %s", err)
+	}
+	return nil
 }
 
 func (s *Service) electNewCrawler(ctx context.Context) (crawlerID string) {
@@ -416,6 +458,10 @@ func (s *Service) setRequestHeaders() http.Header {
 
 func (s *Service) filePath(steamID string) string {
 	return filepath.Join(s.config.Path, fmt.Sprintf("%s.json", steamID))
+}
+
+func (s *Service) filePathPreHash(steamID string) string {
+	return filepath.Join(s.config.Path, fmt.Sprintf("%s.prehash", steamID))
 }
 
 func (s *Service) currentCrawlerID() string {

--- a/phantasm/phantasm.go
+++ b/phantasm/phantasm.go
@@ -36,7 +36,8 @@ const (
 	defaultRecrawlCD        = time.Minute * 10
 	defaultCrawlerCD        = time.Minute
 
-	maxWaitRetry = 5
+	maxWaitRetry         = 5
+	maxFetchRetryAttempt = 10
 )
 
 var (
@@ -394,7 +395,7 @@ func (s *Service) sendCrawlRequest(
 				req.URL.Path = strings.ReplaceAll(req.URL.Path, current, next)
 				_, err1 := sendRequest(req, &summary)
 				return err1
-			}, 3)
+			}, maxFetchRetryAttempt)
 			// check success
 			if err == nil {
 				return &summary, nil

--- a/phantasm/phantasm.go
+++ b/phantasm/phantasm.go
@@ -199,9 +199,6 @@ func (s *Service) crawlWait(ctx context.Context, steamID string) (*inventory, er
 			if err = os.Chtimes(s.filePath(steamID), n, n); err != nil {
 				return nil, err
 			}
-			if err = s.cooldown.SetInventoryHash(ctx, steamID, hash, s.inventoryHashTTL); err != nil {
-				return nil, err
-			}
 			return localFile, nil
 		}
 
@@ -314,7 +311,7 @@ func (s *Service) remoteInventoryChanged(ctx context.Context, steamID string) (b
 		return false, err
 	}
 	if currentHash == "" {
-		logger.DebugContext(ctx, "no inventory hash found, falling back to local pre-hash")
+		logger.DebugContext(ctx, "no inventory hash found in cache, falling back to local pre-hash")
 		currentHash, err = s.localInventoryPreHash(ctx, steamID)
 		if err != nil {
 			logger.Error("local pre-hash error", "err", err)

--- a/scripts/hammer.rql
+++ b/scripts/hammer.rql
@@ -49,6 +49,26 @@ db.table('task').insert({
   })
 })
 
+db.table('market').getAll(200, {index: 'status'})
+  .filter({ type: 10 })
+  .filter(r.row('created_at').date().gt(r.time(2026, 6, 1, 'Z')))
+  .filter(r.row('inventory_status').default(0).eq(0))
+  .count()
+
+db.table('market').getAll(200, {index: 'status'})
+  .filter({ type: 10 })
+  .filter(r.row('created_at').date().gt(r.time(2026, 6, 1, 'Z')))
+  .filter(r.row('inventory_status').default(0).eq(0))
+  .getField('id')
+  .forEach(v => {
+    return db.table('task').insert({
+      type: 2,
+      priority: 3,
+      status: 0,
+      payload: db.table('market').get(v).merge(row => ({ user: db.table('user').get(row('user_id')) })
+    })
+  })
+
 # top search
 r.db('dotagiftx_production')
   .table('track')

--- a/steam/steam.go
+++ b/steam/steam.go
@@ -78,7 +78,7 @@ func (c *Client) Player(steamID string) (*dotagiftx.SteamPlayer, error) {
 }
 
 func (c *Client) ResolveVanityURL(rawURL string) (steamID string, err error) {
-	rawURL = strings.TrimRight(rawURL, "/")
+	rawURL = cleanProfileURL(rawURL)
 
 	// SteamID might be present on the URL provided.
 	if strings.HasPrefix(rawURL, VanityPrefixProfile) {
@@ -103,4 +103,14 @@ func (c *Client) ResolveVanityURL(rawURL string) (steamID string, err error) {
 type cacheReadWriter interface {
 	Set(key string, val interface{}, expr time.Duration) error
 	Get(key string) (val string, err error)
+}
+
+func cleanProfileURL(s string) string {
+	s = strings.TrimRight(s, "/")
+	s = strings.TrimPrefix(s, VanityPrefixProfile)
+	ss := strings.Split(s, "/")
+	if len(ss) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%s%s", VanityPrefixProfile, ss[0])
 }

--- a/steam/steam_test.go
+++ b/steam/steam_test.go
@@ -1,0 +1,34 @@
+package steam
+
+import "testing"
+
+func Test_cleanProfileURL(t *testing.T) {
+	tests := []struct {
+		url  string
+		want string
+	}{
+		{
+			"https://steamcommunity.com/profiles/76561198088587178",
+			"https://steamcommunity.com/profiles/76561198088587178",
+		},
+		{
+			"https://steamcommunity.com/profiles/76561198088587178/",
+			"https://steamcommunity.com/profiles/76561198088587178",
+		},
+		{
+			"https://steamcommunity.com/profiles/76561198088587178/inventory",
+			"https://steamcommunity.com/profiles/76561198088587178",
+		},
+		{
+			"https://steamcommunity.com/profiles/76561198088587178/inventory/#570",
+			"https://steamcommunity.com/profiles/76561198088587178",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.url, func(t *testing.T) {
+			if got := cleanProfileURL(tt.url); got != tt.want {
+				t.Errorf("got: %v, want: %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/steaminvorg/cache.go
+++ b/steaminvorg/cache.go
@@ -3,7 +3,6 @@ package steaminvorg
 import (
 	"context"
 	"fmt"
-	"log"
 	"math/rand/v2"
 	"time"
 
@@ -21,10 +20,10 @@ const (
 
 // InventoryAssetWithCache returns a compact format from all inventory data with cache.
 func InventoryAssetWithCache(ctx context.Context, steamID string) ([]steam.Asset, error) {
-	log.Println("STEAMINVORG CHECK LOCAL CACHE")
+	sharedLogger.Info("check local cache", "steam_id", steamID)
 	hit, _ := filecache.Get(getCacheKey(steamID))
 	if hit != nil {
-		log.Println("STEAMINVORG LOCAL CACHE HIT!")
+		sharedLogger.Info("cache hit", "steam_id", steamID)
 
 		b, _ := fastjson.Marshal(hit)
 		var asset []steam.Asset
@@ -32,19 +31,19 @@ func InventoryAssetWithCache(ctx context.Context, steamID string) ([]steam.Asset
 		return asset, nil
 	}
 
-	log.Println("STEAMINVORG NO LOCAL CACHE HIT", steamID)
+	sharedLogger.Info("no local cache hit", "steam_id", steamID)
 	asset, err := InventoryAsset(ctx, steamID)
 	if err != nil {
-		log.Println("STEAMINVORG ASSET ERROR", steamID, err)
+		sharedLogger.Error("asset error", "steam_id", steamID, "err", err)
 		return nil, err
 	}
 
 	if err = filecache.Set(getCacheKey(steamID), asset, getCacheExpr()); err != nil {
-		log.Println("STEAMINVORG LOCAL CACHE SET ERROR", steamID, err)
+		sharedLogger.Error("local cache set error", "steam_id", steamID, "err", err)
 		return nil, err
 	}
 
-	log.Println("STEAMINVORG ASSET DONE", steamID)
+	sharedLogger.Info("asset done", "steam_id", steamID)
 	return asset, nil
 }
 

--- a/steaminvorg/steaminvorg.go
+++ b/steaminvorg/steaminvorg.go
@@ -66,7 +66,7 @@ func SWR(steamID string, strict bool) (*steam.AllInventory, error) {
 
 	// check for meta until processed with a little bit of back-off
 	for i := 1; i <= maxGetRetries; i++ {
-		sharedLogger.Info("try", steamID, "steam_id", "count", i)
+		sharedLogger.Info("try", "steam_id", steamID, "count", i)
 		m, err = GetMeta(steamID)
 		if err != nil {
 			sharedLogger.Error("try err", "steam_id", steamID, "err", err)

--- a/steaminvorg/steaminvorg.go
+++ b/steaminvorg/steaminvorg.go
@@ -5,8 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
+	"os"
 	"strconv"
 	"time"
 
@@ -21,6 +22,13 @@ const (
 	// freshCacheDur = time.Hour
 	freshCacheDur = time.Minute * 15
 )
+
+var sharedLogger *slog.Logger
+
+func init() {
+	th := slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug})
+	sharedLogger = slog.New(th).With("module", "steaminvorg")
+}
 
 // InventoryAsset returns a compact format from all inventory data.
 func InventoryAsset(ctx context.Context, steamID string) ([]steam.Asset, error) {
@@ -42,46 +50,46 @@ func SWR(steamID string, strict bool) (*steam.AllInventory, error) {
 	// check for freshly cached inventory
 	m, err := GetMeta(steamID)
 	if err != nil && strict {
-		log.Println("STEAMINVORG META ERR", steamID, err)
+		sharedLogger.Error("get meta", "steam_id", steamID, "err", err)
 		return nil, err
 	}
 	if m != nil && m.isCacheFresh() {
-		log.Println("STEAMINVORG CACHED", steamID)
+		sharedLogger.Error("cached", "steam_id", steamID)
 		return Get(steamID)
 	}
 
-	log.Println("STEAMINVORG CRAWL REQUEST", steamID)
+	sharedLogger.Info("crawl request", "steam_id", steamID)
 	if _, err = Crawl(steamID); err != nil {
-		log.Println("STEAMINVORG CRAWL REQUEST ERR", steamID, err)
+		sharedLogger.Error("crawl request", "steam_id", steamID, "err", err)
 		return nil, err
 	}
 
 	// check for meta until processed with a little bit of back-off
 	for i := 1; i <= maxGetRetries; i++ {
-		log.Println("STEAMINVORG TRY", steamID, i)
+		sharedLogger.Info("try", steamID, "steam_id", "count", i)
 		m, err = GetMeta(steamID)
 		if err != nil {
-			log.Println("STEAMINVORG TRY ERR", steamID, err)
+			sharedLogger.Error("try err", "steam_id", steamID, "err", err)
 			return nil, err
 		}
 		if m != nil && m.Status == "success" {
-			log.Println("STEAMINVORG TRY SUCCESS", steamID, i)
+			sharedLogger.Info("try ok", "steam_id", steamID, "count", i)
 			break
 		}
 
 		if i == maxGetRetries {
-			log.Println("STEAMINVORG TIMED OUT", steamID)
+			sharedLogger.Info("timed out", "steam_id", steamID)
 		}
 		time.Sleep(retrySleepDur + time.Duration(i)*time.Second)
 	}
 
 	res, err := Get(steamID)
 	if err != nil {
-		log.Println("STEAMINVORG GET ERR", steamID, err)
+		sharedLogger.Error("get err", "steam_id", steamID, "err", err)
 		return nil, err
 	}
 
-	log.Println("STEAMINVORG GET DONE", steamID)
+	sharedLogger.Info("get done", "steam_id", steamID)
 	return res, nil
 }
 

--- a/worker/tasks.go
+++ b/worker/tasks.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"sync"
 	"time"
 
@@ -20,6 +20,8 @@ type TaskProcessor struct {
 	deliverySvc          dotagiftx.DeliveryService
 	verify               *verify.Source
 	inventoryInvalidator inventoryInvalidator
+
+	logger *slog.Logger
 }
 
 func NewTaskProcessor(
@@ -29,6 +31,7 @@ func NewTaskProcessor(
 	deliverySvc dotagiftx.DeliveryService,
 	source *verify.Source,
 	invInvalidator inventoryInvalidator,
+	logger *slog.Logger,
 ) *TaskProcessor {
 	return &TaskProcessor{
 		queue:                queue,
@@ -37,6 +40,7 @@ func NewTaskProcessor(
 		deliverySvc:          deliverySvc,
 		verify:               source,
 		inventoryInvalidator: invInvalidator,
+		logger:               logger.With("processor", "task"),
 	}
 }
 
@@ -49,7 +53,7 @@ func (p *TaskProcessor) Run(wg *sync.WaitGroup) {
 
 		t, err := p.queue.Get(ctx)
 		if err != nil {
-			log.Printf("ERR! could not get task from queue: %s", err)
+			p.logger.ErrorContext(ctx, "get task from queue", "err", err)
 			continue
 		}
 		if t == nil {
@@ -61,11 +65,15 @@ func (p *TaskProcessor) Run(wg *sync.WaitGroup) {
 
 		task.Status = dotagiftx.TaskStatusProcessing
 		if err = p.queue.Update(ctx, task); err != nil {
-			log.Printf("ERR! could not process task: %s", err)
+			p.logger.ErrorContext(ctx, "mark task status as processing", "err", err)
 			wg.Done()
 			continue
 		}
-		log.Println("task get", task.ID, task.Type, task.Priority)
+		p.logger.InfoContext(ctx, "processing",
+			"id", task.ID,
+			"type", task.Type,
+			"priority", task.Priority,
+		)
 
 		var run func(context.Context, interface{}) error
 		switch task.Type {
@@ -75,24 +83,36 @@ func (p *TaskProcessor) Run(wg *sync.WaitGroup) {
 			run = p.taskVerifyDelivery
 		}
 
-		log.Println("task processing...", task.ID, task.Type)
 		err = run(ctx, task.Payload)
 		task.ElapsedMs = time.Since(start).Milliseconds()
 		if err != nil {
-			log.Printf("ERR! running tasks: %s %s", task.Type, err)
+			p.logger.ErrorContext(ctx, "run task",
+				"id", task.ID,
+				"err", err,
+			)
 			task.Status = dotagiftx.TaskStatusError
 			task.Note = fmt.Sprintf("err: %s", err)
 			if err = p.queue.Update(ctx, task); err != nil {
-				log.Printf("ERR! could not run task: %s", err)
+				p.logger.ErrorContext(ctx, "mark task status as error",
+					"id", task.ID,
+					"err", err,
+				)
 			}
 			wg.Done()
 			continue
 		}
 
 		task.Status = dotagiftx.TaskStatusDone
-		log.Println("task done!", task.ID, time.Duration(task.ElapsedMs)*time.Millisecond)
+		p.logger.InfoContext(ctx, "done",
+			"id", task.ID,
+			"type", task.Type,
+			"elapsed_ms", task.ElapsedMs,
+		)
 		if err = p.queue.Update(ctx, task); err != nil {
-			log.Printf("ERR! could not update task: %s", err)
+			p.logger.ErrorContext(ctx, "mark task status as done",
+				"id", task.ID,
+				"err", err,
+			)
 		}
 		wg.Done()
 	}


### PR DESCRIPTION
phantasm updates
- run exclusively on dgx worker instead on running partly on dgx server
- add auto-retry when fetching inventory
- add auto-rotates crawler sources, slightly improves rate limited responses
- add max fetch retry per crawler rotation
- fix hashing on pre-fetch inventory 
- improve logger

changes
- rework phantasm verification, the system now only runs separately on worker and addresses rate limiting issues
- update hero slug values from their old names
- fix extracting steam id on resolving vanity url
- improve steaminvorg logging
- improve worker task logging