### PR TITLE
fix steam vanity url resolver

### DIFF
--- a/http/svc_user.go
+++ b/http/svc_user.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/kudarap/dotagiftx"
+	"github.com/kudarap/dotagiftx/steam"
 )
 
 const userCacheExpr = time.Minute * 5
@@ -124,7 +125,7 @@ type vanityUserResp struct {
 }
 
 // TODO this should be place on service
-func handleVanityProfile(svc dotagiftx.UserService, steam dotagiftx.SteamClient, cache cacheManager) http.HandlerFunc {
+func handleVanityProfile(svc dotagiftx.UserService, steamClient dotagiftx.SteamClient, cache cacheManager) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// Check for cache hit and render them.
 		cacheKey, noCache := cacheKeyFromRequest(r)
@@ -139,7 +140,7 @@ func handleVanityProfile(svc dotagiftx.UserService, steam dotagiftx.SteamClient,
 
 		// Try to resolve the vanity URL or vanity.
 		id := chi.URLParam(r, "id")
-		steamID, err := steam.ResolveVanityURL(id)
+		steamID, err := steamClient.ResolveVanityURL(fmt.Sprintf(steam.VanityURLPrefix+"%s", id))
 		if err != nil {
 			respondError(w, err)
 			return
@@ -153,7 +154,7 @@ func handleVanityProfile(svc dotagiftx.UserService, steam dotagiftx.SteamClient,
 			vUser.IsRegistered = true
 		} else {
 			// Otherwise, get it from steam API.
-			sp, err := steam.Player(steamID)
+			sp, err := steamClient.Player(steamID)
 			if err != nil {
 				respondError(w, err)
 				return

--- a/steam/player.go
+++ b/steam/player.go
@@ -53,8 +53,8 @@ func GetPlayerSummaries(steamId, apiKey string) (*PlayerSummaries, error) {
 	return &data.Response.Players[0], err
 }
 
-func ResolveVanityURL(vanityURL, apiKey string) (steamID string, err error) {
-	url := fmt.Sprintf("https://api.steampowered.com/ISteamUser/ResolveVanityURL/v1/?key=%s&vanityurl=%s", apiKey, vanityURL)
+func ResolveVanityURL(vanityID, apiKey string) (steamID string, err error) {
+	url := fmt.Sprintf("https://api.steampowered.com/ISteamUser/ResolveVanityURL/v1/?key=%s&vanityurl=%s", apiKey, vanityID)
 	resp, err := http.Get(url)
 	if err != nil {
 		return

--- a/steam/steam.go
+++ b/steam/steam.go
@@ -3,6 +3,7 @@ package steam
 import (
 	"fmt"
 	"net/http"
+	"regexp"
 	"strings"
 	"time"
 
@@ -10,8 +11,8 @@ import (
 )
 
 const (
-	VanityPrefixID      = "https://steamcommunity.com/id/"
-	VanityPrefixProfile = "https://steamcommunity.com/profiles/"
+	VanityURLPrefix  = "https://steamcommunity.com/id/"
+	profileURLPrefix = "https://steamcommunity.com/profiles/"
 
 	vanityCacheExpr = time.Hour * 24
 )
@@ -78,14 +79,19 @@ func (c *Client) Player(steamID string) (*dotagiftx.SteamPlayer, error) {
 }
 
 func (c *Client) ResolveVanityURL(rawURL string) (steamID string, err error) {
-	rawURL = cleanProfileURL(rawURL)
-
-	// SteamID might be present on the URL provided.
-	if strings.HasPrefix(rawURL, VanityPrefixProfile) {
-		return strings.TrimPrefix(rawURL, VanityPrefixProfile), nil
+	url, ok := cleanProfileURL(rawURL)
+	if !ok {
+		return "", fmt.Errorf("could not resolve profile URL: %s", rawURL)
 	}
 
-	vanity := strings.TrimPrefix(rawURL, VanityPrefixID)
+	// SteamID might be present on the URL provided.
+	if after, ok := strings.CutPrefix(url, profileURLPrefix); ok {
+		return after, nil
+	}
+
+	// URL provided could be a vanity type and need to be resolved to
+	// get steam id.
+	vanity := strings.TrimPrefix(url, VanityURLPrefix)
 	cacheKey := fmt.Sprintf("steam/resolvedvanity:%s", vanity)
 	if hit, _ := c.cache.Get(cacheKey); hit != "" {
 		return strings.ReplaceAll(hit, `"`, ""), nil
@@ -105,12 +111,21 @@ type cacheReadWriter interface {
 	Get(key string) (val string, err error)
 }
 
-func cleanProfileURL(s string) string {
-	s = strings.TrimRight(s, "/")
-	s = strings.TrimPrefix(s, VanityPrefixProfile)
-	ss := strings.Split(s, "/")
-	if len(ss) == 0 {
-		return ""
+var reSteamID = regexp.MustCompile("[0-9]{17}")
+
+func cleanProfileURL(rawURL string) (url string, ok bool) {
+	// vanity url mode
+	if v, ok := strings.CutPrefix(rawURL, VanityURLPrefix); ok {
+		s := strings.Split(v, "/")
+		if len(s) == 0 {
+			return "", false
+		}
+		return fmt.Sprintf("%s%s", VanityURLPrefix, s[0]), true
 	}
-	return fmt.Sprintf("%s%s", VanityPrefixProfile, ss[0])
+
+	id := reSteamID.FindString(rawURL)
+	if id == "" {
+		return "", false
+	}
+	return fmt.Sprintf("%s%s", profileURLPrefix, id), true
 }

--- a/steam/steam_test.go
+++ b/steam/steam_test.go
@@ -23,10 +23,22 @@ func Test_cleanProfileURL(t *testing.T) {
 			"https://steamcommunity.com/profiles/76561198088587178/inventory/#570",
 			"https://steamcommunity.com/profiles/76561198088587178",
 		},
+		{
+			"https://steamcommunity.com/id/kudrap",
+			"https://steamcommunity.com/id/kudrap",
+		},
+		{
+			"https://steamcommunity.com/id/kudrap/inventory",
+			"https://steamcommunity.com/id/kudrap",
+		},
+		{
+			"https://steamcommunity.com/id/kudrap/inventory/#570",
+			"https://steamcommunity.com/id/kudrap",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.url, func(t *testing.T) {
-			if got := cleanProfileURL(tt.url); got != tt.want {
+			if got, _ := cleanProfileURL(tt.url); got != tt.want {
 				t.Errorf("got: %v, want: %v", got, tt.want)
 			}
 		})

--- a/web/components/ContactDialog.js
+++ b/web/components/ContactDialog.js
@@ -46,7 +46,7 @@ export default function ContactDialog(props) {
           {moment().diff(moment(market.user.created_at), 'days') <= USER_AGE_CAUTION && (
             <>
               <Alert severity="warning">
-                {`This profile just created ${moment(market.user.created_at).fromNow()}. Please transact with caution.`}
+                {`This user just joined ${moment(market.user.created_at).fromNow()}. Please transact with caution.`}
               </Alert>
               <br />
             </>

--- a/web/components/ProfileCard.js
+++ b/web/components/ProfileCard.js
@@ -2,7 +2,7 @@ import React, { useContext } from 'react'
 import PropTypes from 'prop-types'
 import { makeStyles } from 'tss-react/mui'
 import Typography from '@mui/material/Typography'
-import WarningAmberIcon from '@mui/icons-material/WarningAmber'
+import NewbieIcon from '@mui/icons-material/NewReleases'
 import moment from 'moment'
 import { Box } from '@mui/material'
 import Avatar from '@/components/Avatar'
@@ -111,9 +111,12 @@ export default function ProfileCard({ user, loading, hideSteamProfile, hideInven
         )}
 
         <Typography variant="body2" component="p" color="textSecondary">
-          Joined {moment(user.created_at).fromNow()}{' '}
+          <Typography component="span" variant="caption">
+            {user.steam_id}
+          </Typography>{' '}
+          &middot; Joined {moment(user.created_at).fromNow()}{' '}
           {moment().diff(moment(user.created_at), 'days') <= USER_AGE_CAUTION && (
-            <WarningAmberIcon color="warning" fontSize="inherit" sx={{ mb: -0.3 }} />
+            <NewbieIcon color="info" fontSize="inherit" sx={{ mb: -0.3 }} />
           )}
         </Typography>
         <Typography variant="body2" component="p">

--- a/web/pages/my-listings.js
+++ b/web/pages/my-listings.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { useRouter } from 'next/router'
 import { makeStyles } from 'tss-react/mui'
-import { WarningAmber } from '@mui/icons-material'
+import WarningAmber from '@mui/icons-material/WarningAmber'
 import {
   MARKET_STATUS_LIVE,
   MARKET_STATUS_RESERVED,
@@ -39,6 +39,10 @@ const initialMarketStats = {
   sold: 0,
 }
 
+const marketIssueFilter = {
+  partner_steam_id: 'https:',
+}
+
 export default function MyListings() {
   const { classes } = useStyles()
 
@@ -55,7 +59,7 @@ export default function MyListings() {
       const res = await marketSearch({
         user_id: currentAuth.user_id,
         index: 'user_id',
-        partner_steam_id: 'https:',
+        ...marketIssueFilter,
       })
       setMarketFixes(res?.data || [])
     })()
@@ -114,7 +118,7 @@ export default function MyListings() {
 
           {marketIssues.length != 0 && (
             <TabPanel value={tabValue} index="#fix-broken-partner-steam-id">
-              <BrokenPartnerSteamID />
+              <BrokenPartnerSteamID onReload={handleTableChange} />
             </TabPanel>
           )}
         </Container>
@@ -141,7 +145,7 @@ function Tabs(props) {
           label={
             <>
               <WarningAmber color="warning" fontSize="inherit" sx={{ mr: 0.6, mt: 0.25 }} />
-              Fix Data
+              Fix Steam ID
             </>
           }
           badgeContent={issues}
@@ -182,6 +186,6 @@ const HistoryTable = withDatatableFetch(MyMarketActivity, {
 
 const BrokenPartnerSteamID = withDatatableFetch(FixMyMarketActivity, {
   ...datatableBaseFilter,
-  partner_steam_id: 'https:',
+  ...marketIssueFilter,
   limit: 20,
 })

--- a/web/pages/my-listings.js
+++ b/web/pages/my-listings.js
@@ -2,13 +2,14 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { useRouter } from 'next/router'
 import { makeStyles } from 'tss-react/mui'
+import { WarningAmber } from '@mui/icons-material'
 import {
   MARKET_STATUS_LIVE,
   MARKET_STATUS_RESERVED,
   MARKET_STATUS_SOLD,
   MARKET_TYPE_ASK,
 } from '@/constants/market'
-import { statsMarketSummary } from '@/service/api'
+import { statsMarketSummary, marketSearch } from '@/service/api'
 import Footer from '@/components/Footer'
 import Header from '@/components/Header'
 import Container from '@/components/Container'
@@ -18,6 +19,7 @@ import DashTab from '@/components/DashTab'
 import AppContext from '@/components/AppContext'
 import ReservationList from '@/components/ReservationList'
 import MyMarketActivity from '@/components/MyMarketActivity'
+import FixMyMarketActivity from '@/components/FixMyMarketActivity'
 import withDatatableFetch from '@/components/withDatatableFetch'
 import TabPanel from '@/components/TabPanel'
 
@@ -46,9 +48,21 @@ export default function MyListings() {
   const [marketStats, setMarketStats] = React.useState(initialMarketStats)
   const [tabValue, setTabValue] = React.useState(false)
 
+  // fid market issues needs fixing
+  const [marketIssues, setMarketFixes] = React.useState([])
+  React.useEffect(() => {
+    ;(async () => {
+      const res = await marketSearch({
+        user_id: currentAuth.user_id,
+        index: 'user_id',
+        partner_steam_id: 'https:',
+      })
+      setMarketFixes(res?.data || [])
+    })()
+  }, [])
+
   // tick indicates when to get new stats
   const [tick, setTick] = React.useState(false)
-
   React.useEffect(() => {
     ;(async () => {
       const res = await statsMarketSummary({ user_id: currentAuth.user_id, index: 'user_id' })
@@ -78,7 +92,12 @@ export default function MyListings() {
 
       <main className={classes.main}>
         <Container>
-          <Tabs value={tabValue} onChange={handleTabChange} stats={marketStats} />
+          <Tabs
+            value={tabValue}
+            onChange={handleTabChange}
+            stats={marketStats}
+            issues={marketIssues.length}
+          />
 
           <TabPanel value={tabValue} index="">
             <LiveTable onReload={handleTableChange} />
@@ -92,6 +111,12 @@ export default function MyListings() {
           <TabPanel value={tabValue} index="#history">
             <HistoryTable />
           </TabPanel>
+
+          {marketIssues.length != 0 && (
+            <TabPanel value={tabValue} index="#fix-broken-partner-steam-id">
+              <BrokenPartnerSteamID />
+            </TabPanel>
+          )}
         </Container>
       </main>
 
@@ -101,18 +126,33 @@ export default function MyListings() {
 }
 
 function Tabs(props) {
-  const { stats, ...other } = props
+  const { stats, issues, ...other } = props
+
   return (
     <DashTabs {...other}>
       <DashTab value="" label="Active Listings" badgeContent={stats.live} />
       <DashTab value="#reserved" label="Reserved" badgeContent={stats.reserved} />
       <DashTab value="#delivered" label="Delivered" badgeContent={stats.sold} />
       <DashTab value="#history" label="History" />
+
+      {issues != 0 && (
+        <DashTab
+          value="#fix-broken-partner-steam-id"
+          label={
+            <>
+              <WarningAmber color="warning" fontSize="inherit" sx={{ mr: 0.6, mt: 0.25 }} />
+              Fix Data
+            </>
+          }
+          badgeContent={issues}
+        />
+      )}
     </DashTabs>
   )
 }
 Tabs.propTypes = {
   stats: PropTypes.object.isRequired,
+  issues: PropTypes.number.isRequired,
 }
 
 const datatableBaseFilter = {
@@ -137,5 +177,11 @@ const DeliveredTable = withDatatableFetch(MyMarketActivity, {
 
 const HistoryTable = withDatatableFetch(MyMarketActivity, {
   ...datatableBaseFilter,
+  limit: 20,
+})
+
+const BrokenPartnerSteamID = withDatatableFetch(FixMyMarketActivity, {
+  ...datatableBaseFilter,
+  partner_steam_id: 'https:',
   limit: 20,
 })

--- a/web/pages/profiles/[id].js
+++ b/web/pages/profiles/[id].js
@@ -7,7 +7,7 @@ import { makeStyles } from 'tss-react/mui'
 import Typography from '@mui/material/Typography'
 import Alert from '@mui/material/Alert'
 import moment from 'moment'
-import { WarningAmber } from '@mui/icons-material'
+import NewbieIcon from '@mui/icons-material/NewReleases'
 import { Box } from '@mui/material'
 import {
   APP_NAME,
@@ -236,9 +236,12 @@ export default function UserDetails({
                 </Typography>
               )}
               <Typography variant="body2" component="p" color="textSecondary">
-                Joined {moment(profile.created_at).fromNow()}{' '}
+                <Typography component="span" variant="caption">
+                  {profile.steam_id}
+                </Typography>{' '}
+                &middot; Joined {moment(profile.created_at).fromNow()}{' '}
                 {moment().diff(moment(profile.created_at), 'days') <= USER_AGE_CAUTION && (
-                  <WarningAmber color="warning" fontSize="inherit" sx={{ mb: -0.3 }} />
+                  <NewbieIcon color="info" fontSize="inherit" sx={{ mb: -0.3 }} />
                 )}
               </Typography>
 


### PR DESCRIPTION
closes #182 #183 

changes
- fixes resolving steam vanity ids
- updated caution on newly created account to info instead of warning
- added steam id on profile page and profile card
- added market issue tab on resolving missing or bugged steam ids