### PR TITLE
Potential fix for code scanning alert no. 24: Uncontrolled data used in path expression

### DIFF
--- a/file/file.go
+++ b/file/file.go
@@ -96,13 +96,33 @@ func (l *Local) baseSave(r io.Reader, baseName string) (name string, err error) 
 
 // Get gets file path base on file name and its existence.
 func (l *Local) Get(name string) (path string, err error) {
-	path = filepath.Join(l.Dir(), name)
-	// Check the actual file existence.
-	if _, err := os.Stat(path); os.IsNotExist(err) {
+	if name == "" || strings.Contains(name, "/") || strings.Contains(name, "\\") || strings.Contains(name, "..") {
+		return "", errors.New("invalid file name")
+	}
+
+	baseDir := l.Dir()
+	path = filepath.Join(baseDir, name)
+
+	absBase, err := filepath.Abs(baseDir)
+	if err != nil {
+		return "", err
+	}
+	absPath, err := filepath.Abs(path)
+	if err != nil {
 		return "", err
 	}
 
-	return
+	basePrefix := absBase + string(os.PathSeparator)
+	if absPath != absBase && !strings.HasPrefix(absPath, basePrefix) {
+		return "", errors.New("invalid file path")
+	}
+
+	// Check the actual file existence.
+	if _, err := os.Stat(absPath); os.IsNotExist(err) {
+		return "", err
+	}
+
+	return absPath, nil
 }
 
 // Delete uploaded file base on file name.


### PR DESCRIPTION
Potential fix for [https://github.com/kudarap/dotagiftx/security/code-scanning/24](https://github.com/kudarap/dotagiftx/security/code-scanning/24)

The safest fix is to validate and constrain the filename in `file/file.go` so that `Get` only resolves paths inside the configured storage directory and only accepts single-component file IDs (no separators, no `..`). This preserves existing behavior for normal IDs while blocking traversal attempts.

Best concrete fix in this codebase:
- Edit `file/file.go`, specifically `func (l *Local) Get(name string)`.
- Add input validation before path construction:
  - reject empty names
  - reject names containing `/`, `\`, or `..`
- Build a candidate path with `filepath.Join`, then resolve both base dir and candidate with `filepath.Abs`.
- Enforce containment with a prefix check using `strings.HasPrefix(absPath, absBase+string(os.PathSeparator)) || absPath == absBase`.
- Keep existing existence check via `os.Stat`.
- Reuse already imported packages (`errors`, `os`, `filepath`, `strings`) so no new imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
