### PR TITLE
Potential fix for code scanning alert no. 20: Uncontrolled data used in path expression

### DIFF
--- a/file/file.go
+++ b/file/file.go
@@ -96,6 +96,10 @@ func (l *Local) baseSave(r io.Reader, baseName string) (name string, err error) 
 
 // Get gets file path base on file name and its existence.
 func (l *Local) Get(name string) (path string, err error) {
+	if err = l.validateName(name); err != nil {
+		return "", err
+	}
+
 	path = filepath.Join(l.Dir(), name)
 	// Check the actual file existence.
 	if _, err := os.Stat(path); os.IsNotExist(err) {
@@ -107,6 +111,10 @@ func (l *Local) Get(name string) (path string, err error) {
 
 // Delete uploaded file base on file name.
 func (l *Local) Delete(name string) error {
+	if err := l.validateName(name); err != nil {
+		return err
+	}
+
 	p := filepath.Join(l.Dir(), name)
 	if err := os.Remove(p); err != nil {
 		return err
@@ -118,6 +126,21 @@ func (l *Local) Delete(name string) error {
 // Dir returns save path location.
 func (l *Local) Dir() string {
 	return l.saveDir
+}
+
+func (l *Local) validateName(name string) error {
+	n := strings.TrimSpace(name)
+	if n == "" {
+		return errors.New("file name required")
+	}
+	if filepath.IsAbs(n) {
+		return fmt.Errorf("invalid file name: absolute paths are not allowed")
+	}
+	if strings.Contains(n, "/") || strings.Contains(n, "\\") || strings.Contains(n, "..") {
+		return fmt.Errorf("invalid file name")
+	}
+
+	return nil
 }
 
 func (l *Local) getType(data []byte) (string, error) {


### PR DESCRIPTION
Potential fix for [https://github.com/kudarap/dotagiftx/security/code-scanning/20](https://github.com/kudarap/dotagiftx/security/code-scanning/20)

General fix: validate and constrain any user-influenced filename/path before filesystem operations. Best practice here is to enforce that `name` is a single safe filename component (not a path), since saved files are simple generated names.

Best targeted fix (without changing functionality): in `file/file.go`, add a helper on `Local` to validate `name` by rejecting empty/whitespace names, any path separator (`/` or `\`), any `..` sequence, and any absolute path. Call this helper at the start of both `Get` and `Delete` before `filepath.Join`. This blocks traversal and absolute-path injection for both alert variants and related delete risk.

Changes needed:
- **File:** `file/file.go`
- Add one private method: `validateName(name string) error`
- Update `Get(name string)` to call `validateName` and return error on invalid names.
- Update `Delete(name string)` similarly.
- No new imports required (existing `errors`, `fmt`, `path/filepath`, `strings` suffice).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
