### PR TITLE
Potential fix for code scanning alert no. 9: Incomplete URL substring sanitization

### DIFF
--- a/web/pages/transmute/subscription.js
+++ b/web/pages/transmute/subscription.js
@@ -12,7 +12,14 @@ import Footer from '@/components/Footer'
 import AppContext from '@/components/AppContext'
 import Link from '@/components/Link'
 
-const isPaypalLive = process.env.NEXT_PUBLIC_API_URL.startsWith('https://api.dotagiftx.com')
+const isPaypalLive = (() => {
+  try {
+    const apiUrl = new URL(process.env.NEXT_PUBLIC_API_URL)
+    return apiUrl.protocol === 'https:' && apiUrl.hostname === 'api.dotagiftx.com'
+  } catch {
+    return false
+  }
+})()
 
 const subscriptions = {
   supporter: {


### PR DESCRIPTION
Potential fix for [https://github.com/kudarap/dotagiftx/security/code-scanning/9](https://github.com/kudarap/dotagiftx/security/code-scanning/9)

Use URL parsing and exact host/protocol validation instead of substring/prefix matching.

Best fix (without changing intended functionality): in `web/pages/transmute/subscription.js`, replace the `startsWith` expression on line 15 with a small parsed check:
- Parse `process.env.NEXT_PUBLIC_API_URL` via the built-in `URL` class.
- Confirm protocol is exactly `https:`.
- Confirm hostname is exactly `api.dotagiftx.com`.
- Safely handle invalid/missing env values with `try/catch` and default to `false`.

This preserves current intent (“live only when API URL is exactly the production HTTPS host”) while removing the bypass class.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
