### PR TITLE
Reverse page title order to {PAGE_NAME} :: {APP_NAME}

### DIFF
--- a/web/components/ItemDetails.js
+++ b/web/components/ItemDetails.js
@@ -218,7 +218,7 @@ export default function ItemDetails({
     getBuyOrders(sort)
   }, [tabIndex, sort, page])
 
-  const metaTitle = `${APP_NAME} :: Listings for ${item.name}`
+  const metaTitle = `Listings for ${item.name} :: ${APP_NAME}`
   const rarityText = item.rarity === 'regular' ? '' : ` — ${item.rarity.toString().toUpperCase()}`
   let metaDesc = `Buy ${item.name} from ${item.origin}${rarityText} item for ${item.hero}.`
   const jsonLD = schemaOrgProduct(canonicalURL, item, { description: metaDesc })

--- a/web/components/NotRegisteredProfile.js
+++ b/web/components/NotRegisteredProfile.js
@@ -54,7 +54,7 @@ export default function NotRegisteredProfile({ profile, canonicalURL }) {
   const steamRepURL = `${STEAMREP_PROFILE_BASE_URL}/${profile.steam_id}`
   const dotabuffURL = `${DOTABUFF_PROFILE_BASE_URL}/${profile.steam_id}`
 
-  const metaTitle = `${APP_NAME} :: ${profile.name}`
+  const metaTitle = `${profile.name} :: ${APP_NAME}`
   const metaDesc = `${profile.name}'s Steam profile`
 
   return (

--- a/web/pages/404.js
+++ b/web/pages/404.js
@@ -24,7 +24,7 @@ export default function Custom404({ children }) {
     <>
       <Head>
         <meta charSet="UTF-8" />
-        <title>{APP_NAME} :: 404 - Page Not Found</title>
+        <title>404 - Page Not Found :: {APP_NAME}</title>
       </Head>
 
       <Header />

--- a/web/pages/_app.js
+++ b/web/pages/_app.js
@@ -18,7 +18,7 @@ export default function MyApp(props) {
     <AppCacheProvider {...props}>
       <Head>
         <meta charSet="UTF-8" />
-        <title>{`${APP_NAME} :: Dota 2 Giftables Community Market`}</title>
+        <title>{`Dota 2 Giftables Community Market :: ${APP_NAME}`}</title>
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=6.0" />
       </Head>
       <ThemeProvider theme={theme}>

--- a/web/pages/about.js
+++ b/web/pages/about.js
@@ -32,7 +32,7 @@ export default function About({ build }) {
     <>
       <Head>
         <meta charSet="UTF-8" />
-        <title>{APP_NAME} :: About</title>
+        <title>About :: {APP_NAME}</title>
       </Head>
 
       <Header />

--- a/web/pages/bans.js
+++ b/web/pages/bans.js
@@ -89,7 +89,7 @@ export default function Blacklist() {
     <>
       <Head>
         <meta charSet="UTF-8" />
-        <title>{APP_NAME} :: Banned users</title>
+        <title>Banned users :: {APP_NAME}</title>
       </Head>
 
       <Header />

--- a/web/pages/donate-coin.js
+++ b/web/pages/donate-coin.js
@@ -60,7 +60,7 @@ export default function Faq() {
     <>
       <Head>
         <meta charSet="UTF-8" />
-        <title>{APP_NAME} :: Donate</title>
+        <title>Donate :: {APP_NAME}</title>
       </Head>
 
       <Header />

--- a/web/pages/donate.js
+++ b/web/pages/donate.js
@@ -35,7 +35,7 @@ export default function Faq() {
     <>
       <Head>
         <meta charSet="UTF-8" />
-        <title>{APP_NAME} :: Donate</title>
+        <title>Donate :: {APP_NAME}</title>
       </Head>
 
       <Header />

--- a/web/pages/download.js
+++ b/web/pages/download.js
@@ -65,7 +65,7 @@ export default function Faqs() {
     <>
       <Head>
         <meta charSet="UTF-8" />
-        <title>{APP_NAME} :: DotagiftX for Mobile</title>
+        <title>DotagiftX for Mobile :: {APP_NAME}</title>
       </Head>
 
       <Header />

--- a/web/pages/expiring-posts.js
+++ b/web/pages/expiring-posts.js
@@ -14,7 +14,7 @@ export default function ThanksSubscriber() {
     <div className="container">
       <Head>
         <meta charSet="UTF-8" />
-        <title>{APP_NAME} :: Expiring posts</title>
+        <title>Expiring posts :: {APP_NAME}</title>
       </Head>
 
       <Header />

--- a/web/pages/faqs.js
+++ b/web/pages/faqs.js
@@ -78,7 +78,7 @@ export default function Faqs() {
     <>
       <Head>
         <meta charSet="UTF-8" />
-        <title>{APP_NAME} :: Frequently Asked Questions</title>
+        <title>Frequently Asked Questions :: {APP_NAME}</title>
       </Head>
 
       <Header />

--- a/web/pages/guides.js
+++ b/web/pages/guides.js
@@ -24,7 +24,7 @@ export default function Blacklist() {
     <>
       <Head>
         <meta charSet="UTF-8" />
-        <title>{APP_NAME} :: Guides</title>
+        <title>Guides :: {APP_NAME}</title>
       </Head>
 
       <Header />

--- a/web/pages/heroes.js
+++ b/web/pages/heroes.js
@@ -41,7 +41,7 @@ export default function Heroes({ heroes: allHeroes, error }) {
     <div className="container">
       <Head>
         <meta charSet="UTF-8" />
-        <title>{`${APP_NAME} :: Heroes`}</title>
+        <title>{`Heroes :: ${APP_NAME}`}</title>
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <Header />

--- a/web/pages/history/[status].js
+++ b/web/pages/history/[status].js
@@ -121,7 +121,7 @@ export default function History({ status, summary, error }) {
       <Head>
         <meta charSet="UTF-8" />
         <title>
-          {APP_NAME} :: Market {MARKET_STATUS_MAP_TEXT[status]} History
+          Market {MARKET_STATUS_MAP_TEXT[status]} History :: {APP_NAME}
         </title>
         <meta name="description" content="Market transaction history" />
       </Head>

--- a/web/pages/index.js
+++ b/web/pages/index.js
@@ -102,7 +102,7 @@ export default function Index({ marketSummary, trendingItems }) {
 
   const description = `Search on ${marketSummary.live} Giftable items`
 
-  const metaTitle = `${APP_NAME} :: Dota 2 Giftables Community Market`
+  const metaTitle = `Dota 2 Giftables Community Market :: ${APP_NAME}`
   const metaDesc = `${description}. ${APP_NAME} was made to provide better search and pricing for
           Dota 2 Giftable items like Collector's Caches which are not available on Steam Community Market.
           The project was heavily inspired by Giftable Megathread from r/Dota2Trade.`

--- a/web/pages/login.js
+++ b/web/pages/login.js
@@ -101,7 +101,7 @@ export default function Login() {
     <>
       <Head>
         <meta charSet="UTF-8" />
-        <title>{APP_NAME} :: Sign In</title>
+        <title>Sign In :: {APP_NAME}</title>
       </Head>
 
       <Header />

--- a/web/pages/middleman.js
+++ b/web/pages/middleman.js
@@ -89,7 +89,7 @@ export default function Middleman() {
     <>
       <Head>
         <meta charSet="UTF-8" />
-        <title>{APP_NAME} :: Middleman</title>
+        <title>Middleman :: {APP_NAME}</title>
       </Head>
 
       <Header />

--- a/web/pages/moderators.js
+++ b/web/pages/moderators.js
@@ -73,7 +73,7 @@ export default function Moderators() {
     <>
       <Head>
         <meta charSet="UTF-8" />
-        <title>{APP_NAME} :: Moderators</title>
+        <title>Moderators :: {APP_NAME}</title>
       </Head>
 
       <Header />

--- a/web/pages/plus.js
+++ b/web/pages/plus.js
@@ -65,7 +65,7 @@ export default function Plus() {
     <div className="container">
       <Head>
         <meta charSet="UTF-8" />
-        <title>{APP_NAME} :: Plus</title>
+        <title>Plus :: {APP_NAME}</title>
         <link rel="icon" href="/favicon.ico" />
       </Head>
 

--- a/web/pages/post-item.js
+++ b/web/pages/post-item.js
@@ -12,7 +12,7 @@ export default function About() {
     <>
       <Head>
         <meta charSet="UTF-8" />
-        <title>{APP_NAME} :: Post Item</title>
+        <title>Post Item :: {APP_NAME}</title>
       </Head>
 
       <Header />

--- a/web/pages/post/major-incident-data-loss.js
+++ b/web/pages/post/major-incident-data-loss.js
@@ -13,7 +13,7 @@ export default function ThanksSubscriber() {
     <div className="container">
       <Head>
         <meta charSet="UTF-8" />
-        <title>{APP_NAME} :: Data Loss Incident</title>
+        <title>Data Loss Incident :: {APP_NAME}</title>
       </Head>
 
       <Header />

--- a/web/pages/privacy.js
+++ b/web/pages/privacy.js
@@ -24,7 +24,7 @@ export default function Privacy() {
     <>
       <Head>
         <meta charSet="UTF-8" />
-        <title>{APP_NAME} :: Privacy Policy</title>
+        <title>Privacy Policy :: {APP_NAME}</title>
       </Head>
 
       <Header />

--- a/web/pages/profiles/[id].js
+++ b/web/pages/profiles/[id].js
@@ -143,7 +143,7 @@ export default function UserDetails({
   const steamRepURL = `${STEAMREP_PROFILE_BASE_URL}/${profile.steam_id}`
   const dotabuffURL = `${DOTABUFF_PROFILE_BASE_URL}/${profile.steam_id}`
 
-  const metaTitle = `${APP_NAME} :: ${profile.name}`
+  const metaTitle = `${profile.name} :: ${APP_NAME}`
   let metaDesc = `${profile.name}'s Dota 2 Giftable`
   if (profile.stats) {
     metaDesc += ` ${profile.stats.live} Items · ${profile.stats.reserved} Reserved · ${profile.stats.sold} Delivered`

--- a/web/pages/profiles/[id]/activity.js
+++ b/web/pages/profiles/[id]/activity.js
@@ -102,7 +102,7 @@ export default function UserActivity({ profile, canonicalURL }) {
 
       <Head>
         <meta charSet="UTF-8" />
-        <title>{`${APP_NAME} :: ${profile.name} items`}</title>
+        <title>{`${profile.name} items :: ${APP_NAME}`}</title>
         <meta name="description" content={`${profile.name}'s delivered Giftable items`} />
         <link rel="canonical" href={canonicalURL} />
       </Head>

--- a/web/pages/profiles/[id]/bought.js
+++ b/web/pages/profiles/[id]/bought.js
@@ -103,7 +103,7 @@ export default function UserReserved({ profile, stats, canonicalURL }) {
 
       <Head>
         <meta charSet="UTF-8" />
-        <title>{`${APP_NAME} :: ${profile.name} reserved items`}</title>
+        <title>{`${profile.name} reserved items :: ${APP_NAME}`}</title>
         <meta name="description" content={`${profile.name}'s on-reserved Giftable items`} />
         <link rel="canonical" href={canonicalURL} />
       </Head>

--- a/web/pages/profiles/[id]/delivered.js
+++ b/web/pages/profiles/[id]/delivered.js
@@ -103,7 +103,7 @@ export default function UserDelivered({ profile, stats, canonicalURL }) {
 
       <Head>
         <meta charSet="UTF-8" />
-        <title>{`${APP_NAME} :: ${profile.name} delivered items`}</title>
+        <title>{`${profile.name} delivered items :: ${APP_NAME}`}</title>
         <meta name="description" content={`${profile.name}'s delivered Giftable items`} />
         <link rel="canonical" href={canonicalURL} />
       </Head>

--- a/web/pages/profiles/[id]/reserved.js
+++ b/web/pages/profiles/[id]/reserved.js
@@ -103,7 +103,7 @@ export default function UserReserved({ profile, stats, canonicalURL }) {
 
       <Head>
         <meta charSet="UTF-8" />
-        <title>{`${APP_NAME} :: ${profile.name} reserved items`}</title>
+        <title>{`${profile.name} reserved items :: ${APP_NAME}`}</title>
         <meta name="description" content={`${profile.name}'s on-reserved Giftable items`} />
         <link rel="canonical" href={canonicalURL} />
       </Head>

--- a/web/pages/rules.js
+++ b/web/pages/rules.js
@@ -33,7 +33,7 @@ export default function Version() {
     <div className="container">
       <Head>
         <meta charSet="UTF-8" />
-        <title>{APP_NAME} :: Rules</title>
+        <title>Rules :: {APP_NAME}</title>
         <link rel="icon" href="/favicon.ico" />
       </Head>
 

--- a/web/pages/search.js
+++ b/web/pages/search.js
@@ -79,13 +79,14 @@ export default function Search({ catalogs: initialCatalogs, filter, canonicalURL
     })()
   }, [filter])
 
-  let metaTitle = `${APP_NAME} :: Search`
+  let metaTitle = 'Search'
   let metaDesc = `Search for item name, hero, treasure`
   const searchTerm = filter.q || filter.hero || filter.origin || filter.rarity
   if (searchTerm) {
     metaTitle += ` ${searchTerm}`
     metaDesc = `${catalogs && catalogs.total_count} results for "${searchTerm}"`
   }
+  metaTitle += ` :: ${APP_NAME}`
 
   const linkProps = { href: '/search', query: filter }
 

--- a/web/pages/submit-feedback.js
+++ b/web/pages/submit-feedback.js
@@ -101,7 +101,7 @@ export default function About() {
     <>
       <Head>
         <meta charSet="UTF-8" />
-        <title>{APP_NAME} :: Feedback and Report</title>
+        <title>Feedback and Report :: {APP_NAME}</title>
       </Head>
 
       <Header />

--- a/web/pages/treasures.js
+++ b/web/pages/treasures.js
@@ -49,7 +49,7 @@ export default function Treasures({ treasures, error }) {
     <div className="container">
       <Head>
         <meta charSet="UTF-8" />
-        <title>{`${APP_NAME} :: All Treasures`}</title>
+        <title>{`All Treasures :: ${APP_NAME}`}</title>
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <Header />

--- a/web/pages/updates.js
+++ b/web/pages/updates.js
@@ -113,7 +113,7 @@ export default function Updates() {
     <div className="container">
       <Head>
         <meta charSet="UTF-8" />
-        <title>{APP_NAME} :: Updates</title>
+        <title>Updates :: {APP_NAME}</title>
       </Head>
 
       <Header />


### PR DESCRIPTION
Closes #60

Reverses page titles from `{APP_NAME} :: {PAGE_NAME}` to `{PAGE_NAME} :: {APP_NAME}` across all pages (32 files, one line each). Also flips the og:title/twitter:title tags fed by metaTitle, and restructures the search page title so the search term appears before the app name.
