### PR TITLE
add arcana, immortal, and persona rarity tiers with glow

### DIFF
--- a/web/components/ItemImage.js
+++ b/web/components/ItemImage.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import Image from 'next/image'
 import Box from '@mui/material/Box'
 import { CDN_URL } from '@/service/api'
-import { itemRarityColorMap } from '@/constants/palette'
+import { itemRarityColorMap, itemRarityGlowSet } from '@/constants/palette'
 
 const baseSizeQuality = 20
 export function retinaSrcSet(filename, width, height) {
@@ -26,7 +26,11 @@ export default function ItemImage({ image, title, rarity, className, width, heig
     flexDirection: 'column',
   }
   if (rarity) {
-    containerStyle.border = `1px solid ${itemRarityColorMap[rarity]}`
+    const color = itemRarityColorMap[rarity]
+    containerStyle.border = `1px solid ${color}`
+    if (itemRarityGlowSet.includes(rarity)) {
+      containerStyle.boxShadow = `0 0 8px ${color}`
+    }
   }
 
   const imageStyle = {

--- a/web/components/RarityTag.js
+++ b/web/components/RarityTag.js
@@ -5,6 +5,9 @@ import {
   ITEM_RARITY_RARE,
   ITEM_RARITY_ULTRA_RARE,
   ITEM_RARITY_VERY_RARE,
+  ITEM_RARITY_ARCANA,
+  ITEM_RARITY_IMMORTAL,
+  ITEM_RARITY_PERSONA,
 } from '@/constants/palette'
 
 // background: linear-gradient(#f9ffbf 10%, #fff 90%);
@@ -26,6 +29,9 @@ const rarityStylerMap = {
   rare: { color: ITEM_RARITY_RARE },
   'very rare': { color: ITEM_RARITY_VERY_RARE },
   'ultra rare': { color: ITEM_RARITY_ULTRA_RARE },
+  arcana: { color: ITEM_RARITY_ARCANA },
+  immortal: { color: ITEM_RARITY_IMMORTAL },
+  persona: { color: ITEM_RARITY_PERSONA },
 }
 
 const getRarityStyle = value => {

--- a/web/constants/palette.js
+++ b/web/constants/palette.js
@@ -1,9 +1,18 @@
 export const ITEM_RARITY_RARE = '#8ec021'
 export const ITEM_RARITY_VERY_RARE = '#fb8600'
 export const ITEM_RARITY_ULTRA_RARE = '#e2ac3f'
+export const ITEM_RARITY_ARCANA = '#ade55c'
+export const ITEM_RARITY_IMMORTAL = '#b28a33'
+export const ITEM_RARITY_PERSONA = '#d32ce6'
 
 export const itemRarityColorMap = {
   rare: ITEM_RARITY_RARE,
   'very rare': ITEM_RARITY_VERY_RARE,
   'ultra rare': ITEM_RARITY_ULTRA_RARE,
+  arcana: ITEM_RARITY_ARCANA,
+  immortal: ITEM_RARITY_IMMORTAL,
+  persona: ITEM_RARITY_PERSONA,
 }
+
+// Rarities that get a glow effect around their item image border.
+export const itemRarityGlowSet = ['arcana', 'immortal']


### PR DESCRIPTION
Closes #120

Adds the three missing rarity tiers to the frontend color/style mapping:

- arcana #ade55c
- immortal #b28a33
- persona #d32ce6